### PR TITLE
feat: allow self-signed certificate write as the user

### DIFF
--- a/bin/insights-proxy
+++ b/bin/insights-proxy
@@ -57,10 +57,6 @@ function copy_env {
 if [ "${COMMAND}" == "install" ]; then
 
   mkdir -p "${INSIGHTS_PROXY_USER_PATH}/certs"
-  # Insights-Proxy running as 1001 would be writing the
-  # self signed certificates if not there so we need
-  # write permission.
-  chmod 777 "${INSIGHTS_PROXY_USER_PATH}/certs"
 
   systemctl --user reset-failed
 

--- a/config/insights-proxy.container
+++ b/config/insights-proxy.container
@@ -10,6 +10,9 @@ ExposeHostPort=3128
 EnvironmentFile=%h/.config/insights-proxy/env/insights-proxy.env
 EnvironmentFile=%h/.config/insights-proxy/env/insights-proxy-servers.env
 Volume=%h/.local/share/insights-proxy/certs:/opt/app-root/certs:z
+# Since we could write self-generated keys to the shared certs volume
+# Let's make sure we map the nginx user to the host's user.
+UserNS=keep-id:uid=1001,gid=1001
 
 [Service]
 ExecStartPre=/bin/sh -c 'echo INSIGHTS_PROXY_SERVER_NAMES=$(cat %h/.config/insights-proxy/env/insights-proxy.servers | egrep -v "^#|^$|^[ \t]*$" | tr "\n" " ") > %h/.config/insights-proxy/env/insights-proxy-servers.env'


### PR DESCRIPTION
- Allow writing the self-signed certificate to the shared certs volume as the user. This way we don't need to make that directory writable by the world.