### PR TITLE
feat: configure the server to use the system DNS resolver

### DIFF
--- a/bin/insights-proxy-configure
+++ b/bin/insights-proxy-configure
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Insights Proxy Configuration.
+#
+# Customize/Update the service environment before starting up the NGINX Proxy Server.
+#
+
+export PROXY_ENVFILE="insights-proxy.env"
+export SERVERS_ENVFILE="insights-proxy-servers.env"
+
+[ $# -ne 1 ] && echo "Usage: ${0} service-environment-directory" >&2 && exit 1
+
+export ENV_DIR="${1}"
+shift
+
+[ ! -d "${ENV_DIR}" ] && echo "Insights Proxy environment directory ${ENV_DIR} does not exist" >&2 && exit 1
+
+cd "${ENV_DIR}"
+
+#
+# Let's define the INSIGHTS_PROXY_SERVER_NAMES environment based on the servers list
+#
+
+echo -n "INSIGHTS_PROXY_SERVER_NAMES=" > "${SERVERS_ENVFILE}"
+cat insights-proxy.servers | egrep -v "^#|^$|^[ \t]*$" | tr "\n" " " >> "${SERVERS_ENVFILE}"
+echo >> "${SERVERS_ENVFILE}"
+
+#
+# Let's define the resolver to use for the NGINX Server.
+#
+
+export SYSTEM_DNS_RESOLVER=$(awk '/^nameserver/{print $2; exit;}' /etc/resolv.conf)
+export DNS_RESOLVER="${SYSTEM_DNS_RESOLVER:=1.1.1.1}"
+sed -i "s/^INSIGHTS_PROXY_DNS_SERVER=.*/INSIGHTS_PROXY_DNS_SERVER=${DNS_RESOLVER}/" "${PROXY_ENVFILE}"
+

--- a/config/insights-proxy.container
+++ b/config/insights-proxy.container
@@ -18,7 +18,7 @@ Volume=%h/.local/share/insights-proxy/download:/opt/app-root/download:z
 UserNS=keep-id:uid=1001,gid=1001
 
 [Service]
-ExecStartPre=/bin/sh -c 'cd %h/.config/insights-proxy/env; echo -n "INSIGHTS_PROXY_SERVER_NAMES=" > "insights-proxy-servers.env"; cat insights-proxy.servers | egrep -v "^#|^$|^[ \t]*$" | tr "\n" " " >> "insights-proxy-servers.env"; echo >> "insights-proxy-servers.env"'
+ExecStartPre=/bin/sh -c '/usr/share/insights-proxy/bin/insights-proxy-configure %h/.config/insights-proxy/env'
 Restart=always
 TimeoutStartSec=600
 

--- a/insights-proxy.spec
+++ b/insights-proxy.spec
@@ -23,6 +23,7 @@ the Insights Proxy via a systemd quadlet service.
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_datadir}/%{name}/bin
 cp bin/%{name} %{buildroot}/%{_bindir}/%{name}
+cp bin/insights-proxy-configure %{buildroot}/%{_datadir}/%{name}/bin/insights-proxy-configure
 mkdir -p %{buildroot}/%{_datadir}/%{name}/config
 cp config/*.container %{buildroot}/%{_datadir}/%{name}/config/
 mkdir -p %{buildroot}/%{_datadir}/%{name}/env
@@ -35,6 +36,7 @@ cp download/bin/*.template %{buildroot}/%{_datadir}/%{name}/download/bin/
 %license LICENSE
 %doc README.md
 %{_bindir}/%{name}
+%{_datadir}/%{name}/bin/insights-proxy-configure
 %{_datadir}/%{name}/config/insights-proxy.container
 %{_datadir}/%{name}/env/insights-proxy.env
 %{_datadir}/%{name}/env/insights-proxy.servers
@@ -43,7 +45,7 @@ cp download/bin/*.template %{buildroot}/%{_datadir}/%{name}/download/bin/
 %changelog
 * Tue Jul 02 2024 Alberto Bellotti <abellott@redhat.com>
 - Version 1.2
-- Adding support for
+- Additional enhancements
 
 * Fri Jun 28 2024 Alberto Bellotti <abellott@redhat.com>
 - Version 1.1


### PR DESCRIPTION
- Updated the insights proxy service to define the DNS resolver used by the NGINX proxy engine to be the system defined DNS resolver.  (what gets declared in /etc/resolv.conf) Only if that's not defined (should not be), we'll default to the 1.1.1.1 resolver (Cloudflare).